### PR TITLE
Use xdg-open also for FreeBSD

### DIFF
--- a/R/openFile.R
+++ b/R/openFile.R
@@ -34,9 +34,9 @@ file,
 file <- normalizePath(file, winslash="/", mustWork=FALSE)
 checkFile(file)
 file <- shQuote(file) # to handle space in "C:/Program Files/R/..."
-linux <- Sys.info()["sysname"]=="Linux"
-out <- try(if(!linux) system2("open", file, ...) else  # Windows
-                      system2("xdg-open", file, ...),  # Linux
+unix <- Sys.info()["sysname"] %in% c("Linux", "FreeBSD")
+out <- try(if(!unix) system2("open", file, ...) else   # Windows
+                      system2("xdg-open", file, ...),  # Unix
            silent=TRUE)
 return(invisible(out))
 }


### PR DESCRIPTION
There is no 'open' in FreeBSD, but 'xdg-open' like in Linux.